### PR TITLE
ユーザー認証機能を実装

### DIFF
--- a/src/app/Http/Controllers/AuthController.php
+++ b/src/app/Http/Controllers/AuthController.php
@@ -7,10 +7,11 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Validator;
 
 class AuthController extends Controller
 {
-    //ユーザー登録
+    // ユーザー登録
   public function register(Request $request) {
     $rules = [
       "name" => ["required", "string", "max:50"],
@@ -34,5 +35,30 @@ class AuthController extends Controller
         "data" => $user,
     ];
     return response()->json($json, Response::HTTP_OK);
+  }
+
+  // ログイン
+  public function login(Request $request) {
+    $rules = [
+      "email" => ["required", "string", "email", "max:255"],
+      "password" => ["required", "string", "min:8", "max:50"],
+    ];
+    $validator = Validator::make($request->all(), $rules);
+
+    if ($validator->fails()) {
+      return response()->json($validator->errors(), Response::HTTP_BAD_REQUEST);
+    }
+
+    $data = $request->only(["email", "password"]);
+
+    if (Auth::attempt($data)) {
+      $user = User::where("email", $data["email"])->first();
+      $user->tokens()->delete();
+      $token = $user->createToken("login:user{$user->id}")->plainTextToken;
+
+      return response()->json(["token" => $token], Response::HTTP_OK);
+    }
+
+    return response()->json('認証に失敗しました', Response::HTTP_UNAUTHORIZED);
   }
 }

--- a/src/app/Http/Controllers/AuthController.php
+++ b/src/app/Http/Controllers/AuthController.php
@@ -61,4 +61,12 @@ class AuthController extends Controller
 
     return response()->json('認証に失敗しました', Response::HTTP_UNAUTHORIZED);
   }
+
+  // ログアウト
+  public function logout(Request $request) {
+    $request->user()->tokens()->delete();
+    Auth::guard("web")->logout();
+    $cookie = \Cookie::forget('laravel_session');
+    return response()->json('ログアウトしました', Response::HTTP_OK)->withCookie($cookie);
+  }
 }

--- a/src/app/Http/Kernel.php
+++ b/src/app/Http/Kernel.php
@@ -39,7 +39,7 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
-            // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
+            \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
             \Illuminate\Routing\Middleware\ThrottleRequests::class.':api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],

--- a/src/app/Http/Middleware/VerifyCsrfToken.php
+++ b/src/app/Http/Middleware/VerifyCsrfToken.php
@@ -12,6 +12,7 @@ class VerifyCsrfToken extends Middleware
      * @var array<int, string>
      */
     protected $except = [
+        "/api/*"
         //
     ];
 }

--- a/src/config/cors.php
+++ b/src/config/cors.php
@@ -29,6 +29,6 @@ return [
 
     'max_age' => 0,
 
-    'supports_credentials' => false,
+    'supports_credentials' => true,
 
 ];

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -19,3 +19,4 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 });
 
 Route::post('/register', 'App\Http\Controllers\AuthController@register');
+Route::post('/login', 'App\Http\Controllers\AuthController@login');

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -19,4 +19,4 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 });
 
 Route::post('/register', 'App\Http\Controllers\AuthController@register');
-Route::post('/login', 'App\Http\Controllers\AuthController@login');
+Route::post('/login', 'App\Http\Controllers\AuthController@login')->name('login');

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\AuthController;
 
 /*
 |--------------------------------------------------------------------------
@@ -14,9 +15,11 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
+Route::post('/register', [AuthController::class, 'register']);
+Route::post('/login', [AuthController::class, 'login'])->name('login');
+
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 
-Route::post('/register', 'App\Http\Controllers\AuthController@register');
-Route::post('/login', 'App\Http\Controllers\AuthController@login')->name('login');
+Route::middleware('auth:sanctum')->post('/logout', [AuthController::class, 'logout']);


### PR DESCRIPTION
### 概要
Laravelが用意しているSanctumを使用し、セッションベースの認証機能を実装。またログアウト時にはLaravel側で保存しているCookieを削除するように実装してある。
今回はローカル環境なので問題ないが、デプロイする際はフロント側のドメインを設定しないとSanctumでのAPI通信はエラーが出ると思うので注意！

### 該当Isssue
#1 