### PR TITLE
タグを使った検索機能を実装

### DIFF
--- a/src/app/Http/Controllers/AuthController.php
+++ b/src/app/Http/Controllers/AuthController.php
@@ -18,28 +18,23 @@ class AuthController extends Controller
     $this->user = new User();
   }
 
-    // ユーザー登録
   public function register(RegisterRequest $request) {
     $registerData = $request->validated();
     $user = $this->user->createUser($registerData);
     return response()->json($user, Response::HTTP_CREATED);
   }
 
-  // ログイン
   public function login(LoginRequest $request) {
     $loginData = $request->validated();
-
     if (Auth::attempt($loginData)) {
       $user = $this->user->loginUser($loginData);
       $token = $user->generateAuthToken();
-
-      return response()->json($token, Response::HTTP_OK);
+      return response()->json(["token" => $token, "user" => $user], Response::HTTP_OK);
     }
 
     return response()->json('認証に失敗しました', Response::HTTP_UNAUTHORIZED);
   }
 
-  // ログアウト
   public function logout(Request $request) {
     $request->user()->deleteAuthTokens();
     Auth::guard("web")->logout();

--- a/src/app/Http/Controllers/PostController.php
+++ b/src/app/Http/Controllers/PostController.php
@@ -48,7 +48,8 @@ class PostController extends Controller
 
   public function update(PostRequest $request, $id) {
     $postData = $request->validated();
-    $post = $this->post->updatePostById($id, $postData);
+    $tags = $postData["tags"];
+    $post = $this->post->updatePostById($id, $postData, $tags);
     return response()->json($post, Response::HTTP_OK);
   }
 

--- a/src/app/Http/Controllers/PostController.php
+++ b/src/app/Http/Controllers/PostController.php
@@ -6,6 +6,7 @@ use App\Models\Post;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\PostRequest;
+use App\Http\Requests\SearchPostsByTagRequest;
 // use Illuminate\Support\Facades\Storage;
 
 class PostController extends Controller
@@ -53,5 +54,15 @@ class PostController extends Controller
   public function destroy($id) {
     $this->post->deletePostById($id);
     return response()->json(Response::HTTP_NO_CONTENT);
+  }
+
+  public function searchByTag(SearchPostsByTagRequest $request) {
+    $tagName = $request->input("tag_name");
+    $posts = $this->post->findByTag($tagName);
+    if ($posts->isEmpty()) {
+      return response()->json(["message" => "投稿が見つかりませんでした。"], Response::HTTP_OK);
+    }
+
+    return response()->json($posts, Response::HTTP_OK);
   }
 }

--- a/src/app/Http/Controllers/PostController.php
+++ b/src/app/Http/Controllers/PostController.php
@@ -41,7 +41,8 @@ class PostController extends Controller
     //   $postData['image'] = Storage::url($path);
     // }
 
-    $post = $this->post->createPost($postData);
+    $tags = $postData["tags"];
+    $post = $this->post->createPost($postData, $tags);
     return response()->json($post, Response::HTTP_CREATED);
   }
 

--- a/src/app/Http/Controllers/PostController.php
+++ b/src/app/Http/Controllers/PostController.php
@@ -62,7 +62,7 @@ class PostController extends Controller
     $tagName = $request->input("tag_name");
     $posts = $this->post->findByTag($tagName);
     if ($posts->isEmpty()) {
-      return response()->json(["message" => "投稿が見つかりませんでした。"], Response::HTTP_OK);
+      return response()->json(["data" => []], Response::HTTP_OK);
     }
 
     return response()->json($posts, Response::HTTP_OK);

--- a/src/app/Http/Requests/PostRequest.php
+++ b/src/app/Http/Requests/PostRequest.php
@@ -25,6 +25,8 @@ class PostRequest extends FormRequest
       "title" => ["required", "string", "max:255"],
       "content" => ["required", "string", "max:1000"],
       "image" => ["nullable", "file", "image", "mimes:jpeg,png,jpg,webp", "max:2048"],
+      "tags" => ["nullable", "array", "max:3"],
+      "tags.*" => ["string", "max:255"],
     ];
   }
 }

--- a/src/app/Http/Requests/SearchPostsByTagRequest.php
+++ b/src/app/Http/Requests/SearchPostsByTagRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SearchPostsByTagRequest extends FormRequest
+{
+	/**
+	 * Determine if the user is authorized to make this request.
+	 */
+	public function authorize(): bool
+	{
+		return true;
+	}
+
+	/**
+	 * Get the validation rules that apply to the request.
+	 *
+	 * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+	 */
+	public function rules(): array
+	{
+		return [
+			"tag_name" => ["required", "string", "max:255"],
+		];
+	}
+}

--- a/src/app/Models/Post.php
+++ b/src/app/Models/Post.php
@@ -26,7 +26,7 @@ class Post extends Model
 
   public function getAllPosts() {
     return Post::with(["user:id,name", "tags:id,name"])->
-      orderBy("created_at", "desc")->
+      latest()->
       paginate(15);
   }
 
@@ -51,6 +51,6 @@ class Post extends Model
   public function findByTag($tagName) {
     return Post::whereHas("tags", function ($query) use ($tagName) {
       $query->where("name", "LIKE", "%{$tagName}%");
-    })->with(["user:id,name", "tags:id,name"])->orderBy("created_at", "desc")->paginate(15);
+    })->with(["user:id,name", "tags:id,name"])->latest()->paginate(15);
   }
 }

--- a/src/app/Models/Post.php
+++ b/src/app/Models/Post.php
@@ -25,13 +25,13 @@ class Post extends Model
   }
 
   public function getAllPosts() {
-    return Post::with("user")->
+    return Post::with(["user:id,name", "tags:id,name"])->
       orderBy("created_at", "desc")->
       paginate(15);
   }
 
   public function getPostById($id) {
-    return Post::with("user")->find($id);
+    return Post::with(["user:id,name", "tags:id,name"])->find($id);
   }
 
   public function createPost($postData) {
@@ -39,7 +39,7 @@ class Post extends Model
   }
 
   public function updatePostById($id, $postData) {
-    $post = Post::with("user")->find($id);
+    $post = Post::with("user:id,name")->find($id);
     $post->fill($postData)->save();
     return $post;
   }
@@ -51,6 +51,6 @@ class Post extends Model
   public function findByTag($tagName) {
     return Post::whereHas("tags", function ($query) use ($tagName) {
       $query->where("name", "LIKE", "%{$tagName}%");
-    })->with(["user", "tags"])->orderBy("created_at", "desc")->paginate(15);
+    })->with(["user:id,name", "tags:id,name"])->orderBy("created_at", "desc")->paginate(15);
   }
 }

--- a/src/app/Models/Post.php
+++ b/src/app/Models/Post.php
@@ -47,4 +47,10 @@ class Post extends Model
   public function deletePostById($id) {
     return Post::find($id)->destroy($id);
   }
+
+  public function findByTag($tagName) {
+    return Post::whereHas("tags", function ($query) use ($tagName) {
+      $query->where("name", "LIKE", "%{$tagName}%");
+    })->with(["user", "tags"])->orderBy("created_at", "desc")->paginate(15);
+  }
 }

--- a/src/app/Models/Post.php
+++ b/src/app/Models/Post.php
@@ -9,6 +9,8 @@ class Post extends Model
 {
   use HasFactory;
 
+  const PAGINATION_COUNT = 15;
+
   protected $fillable = [
     "user_id",
     "title",
@@ -25,42 +27,46 @@ class Post extends Model
   }
 
   public function getAllPosts() {
-    return Post::with(["user:id,name", "tags:id,name"])->
+    return $this->with(["user:id,name", "tags:id,name"])->
       latest()->
-      paginate(15);
+      paginate(self::PAGINATION_COUNT);
   }
 
   public function getPostById($id) {
-    return Post::with(["user:id,name", "tags:id,name"])->find($id);
+    return $this->with(["user:id,name", "tags:id,name"])->find($id);
   }
 
   public function createPost($postData, $tags = []) {
-    $post = Post::create($postData);
-
-    if (!empty($tags)) {
-      $tagIds = [];
-      foreach ($tags as $tagName) {
-        $tag = Tag::firstOrCreate(["name" => $tagName]);
-        $tagIds[] = $tag->id;
-      }
-      $post->tags()->sync($tagIds);
-    }
+    $post = $this->create($postData);
+    $this->syncTags($post, $tags);
     return $post;
   }
 
-  public function updatePostById($id, $postData) {
-    $post = Post::with("user:id,name")->find($id);
+  public function updatePostById($id, $postData, $tags = []) {
+    $post = $this->with("user:id,name")->find($id);
     $post->fill($postData)->save();
+    $this->syncTags($post, $tags);
+    $post = $this->with(["user:id,name", "tags:id,name"])->find($post->id);
     return $post;
   }
 
   public function deletePostById($id) {
-    return Post::find($id)->destroy($id);
+    return $this->find($id)->destroy($id);
   }
 
   public function findByTag($tagName) {
-    return Post::whereHas("tags", function ($query) use ($tagName) {
+    return $this->whereHas("tags", function ($query) use ($tagName) {
       $query->where("name", "LIKE", "%{$tagName}%");
-    })->with(["user:id,name", "tags:id,name"])->latest()->paginate(15);
+    })->with(["user:id,name", "tags:id,name"])->latest()->paginate(self::PAGINATION_COUNT);
+  }
+
+  // 投稿とタグのリレーションを同期
+  protected function syncTags($post, $tags) {
+    $tagIds = [];
+    foreach ($tags as $tagName) {
+      $tag = Tag::firstOrCreate(["name" => $tagName]);
+      $tagIds[] = $tag->id;
+    }
+    $post->tags()->sync($tagIds);
   }
 }

--- a/src/app/Models/Post.php
+++ b/src/app/Models/Post.php
@@ -20,6 +20,10 @@ class Post extends Model
     return $this->belongsTo(User::class);
   }
 
+  public function tags() {
+    return $this->belongsToMany(Tag::class);
+  }
+
   public function getAllPosts() {
     return Post::with("user")->
       orderBy("created_at", "desc")->

--- a/src/app/Models/Post.php
+++ b/src/app/Models/Post.php
@@ -34,8 +34,18 @@ class Post extends Model
     return Post::with(["user:id,name", "tags:id,name"])->find($id);
   }
 
-  public function createPost($postData) {
-    return Post::create($postData);
+  public function createPost($postData, $tags = []) {
+    $post = Post::create($postData);
+
+    if (!empty($tags)) {
+      $tagIds = [];
+      foreach ($tags as $tagName) {
+        $tag = Tag::firstOrCreate(["name" => $tagName]);
+        $tagIds[] = $tag->id;
+      }
+      $post->tags()->sync($tagIds);
+    }
+    return $post;
   }
 
   public function updatePostById($id, $postData) {

--- a/src/app/Models/Tag.php
+++ b/src/app/Models/Tag.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Tag extends Model
+{
+	use HasFactory;
+
+	protected $fillable = [
+		"name",
+	];
+
+	public function posts() {
+		return $this->belongsToMany(Post::class);
+	}
+}

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -49,7 +49,7 @@ class User extends Authenticatable
   }
 
   public function createUser($registerData) {
-    return User::create([
+    return $this->create([
       "name" => $registerData["name"],
       "email" => $registerData["email"],
       "password" => Hash::make($registerData["password"]),
@@ -57,7 +57,7 @@ class User extends Authenticatable
   }
 
   public function loginUser($loginData) {
-    return User::where("email", $loginData["email"])->first();
+    return $this->where("email", $loginData["email"])->first();
   }
 
   public function generateAuthToken() {

--- a/src/database/migrations/2024_02_08_050641_create_tags_table.php
+++ b/src/database/migrations/2024_02_08_050641_create_tags_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tags');
+    }
+};

--- a/src/database/migrations/2024_02_08_082754_create_post_tag_table.php
+++ b/src/database/migrations/2024_02_08_082754_create_post_tag_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('post_tag', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('post_id')->constrained()->onDelete('cascade');
+            $table->foreignId('tag_id')->constrained()->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('post_tag');
+    }
+};

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -24,6 +24,7 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 });
 Route::middleware('auth:sanctum')->post('/logout', [AuthController::class, 'logout']);
 
+Route::get('/posts/tags', [PostController::class, 'searchByTag']);
 Route::get('/posts', [PostController::class, 'index']);
 Route::get('/posts/{id}', [PostController::class, 'show']);
 Route::middleware('auth:sanctum')->post('/posts', [PostController::class, 'store']);


### PR DESCRIPTION
### 概要
タグ検索機能の実装に伴い、投稿データ取得時に紐づいたタグも取得できるように修正。投稿作成・更新時はタグがない状態でも作成・更新できるようにし、タグは最大で3つまで保存できる実装にした。

一部リファクタリングも行い、以下のことを変更した。

1. orderByメソッドからlatestメソッドに修正。
　latestメソッドはデフォルトでcreated_atの降順でデータを取得するので可読性が上がると判断。またidを降順で取得したい場合はメソッドの引数にidを指定すればOK。

2. モデル内でメソッドを使う際は、モデル名:: を使うのではなく、$this->を使ったコードに修正。
　モデル名::メソッドと$this->メソッドのコードが混ざっていたため、$thisを使ったメソッドの実行に統一。

3. ログイン成功時はトークンと一緒にユーザー情報も返却するように修正。
　API通信の回数を減らすために修正。フロント側でトークンを取得後にユーザー情報を取得する関数を実行していたが、ログイン成功時のレスポンスでトークンとユーザー情報を返却するようにすれば、わざわざユーザー情報を取得する関数を実行する必要がなくなると判断し修正。

### 該当Issue
#14 