### PR TITLE
フロントからのリクエスト時に413エラーが出るバグを修正 

### DIFF
--- a/docker/php/php.ini
+++ b/docker/php/php.ini
@@ -3,3 +3,5 @@ date.timezone = "Asia/Tokyo"
 [mbstring]
 mbstring.internal_encoding = "UTF-8"
 mbstring.language = "Japanese"
+post_max_size = 10M
+upload_max_filesize = 10M

--- a/docker/web/default.conf
+++ b/docker/web/default.conf
@@ -1,39 +1,41 @@
 server {
-    listen 80;
-    listen [::]:80;
-    # ルートディレクトリを指定
-    root /var/www/html/public;
+  listen 80;
+  listen [::]:80;
+  # ルートディレクトリを指定
+  root /var/www/html/public;
 
-    add_header X-Frame-Options "SAMEORIGIN";
-    add_header X-Content-Type-Options "nosniff";
+  add_header X-Frame-Options "SAMEORIGIN";
+  add_header X-Content-Type-Options "nosniff";
 
-    index index.php;
+  index index.php;
 
-    charset utf-8;
+  charset utf-8;
 
-    location / {
-      try_files $uri $uri/ /index.php?$query_string;
+  client_max_body_size 10M;
+
+  location / {
+    try_files $uri $uri/ /index.php?$query_string;
+  }
+
+  location = /favicon.ico {
+    access_log off;
+    log_not_found off;
+    }
+  location = /robots.txt  {
+    access_log off;
+    log_not_found off;
     }
 
-    location = /favicon.ico {
-      access_log off;
-      log_not_found off;
-      }
-    location = /robots.txt  {
-      access_log off;
-      log_not_found off;
-      }
+  error_page 404 /index.php;
 
-    error_page 404 /index.php;
+  location ~ \.php$ {
+    # PHP-FPMはデフォルトで9000番のポートを使用するため、PHPコンテナの9000番へルーティング
+    fastcgi_pass php:9000;
+    fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+    include fastcgi_params;
+  }
 
-    location ~ \.php$ {
-        # PHP-FPMはデフォルトで9000番のポートを使用するため、PHPコンテナの9000番へルーティング
-        fastcgi_pass php:9000;
-        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
-        include fastcgi_params;
-    }
-
-    location ~ /\.(?!well-known).* {
-        deny all;
-    }
+  location ~ /\.(?!well-known).* {
+    deny all;
+  }
 }

--- a/src/app/Http/Requests/PostRequest.php
+++ b/src/app/Http/Requests/PostRequest.php
@@ -24,7 +24,7 @@ class PostRequest extends FormRequest
     return [
       "title" => ["required", "string", "max:255"],
       "content" => ["required", "string", "max:1000"],
-      "image" => ["nullable", "file", "image", "mimes:jpeg,png,jpg,webp", "max:2048"],
+      "image" => ["nullable", "file", "mimes:jpeg,png,jpg,webp"],
       "tags" => ["nullable", "array", "max:3"],
       "tags.*" => ["string", "max:255"],
     ];


### PR DESCRIPTION
### 概要
Nginxはデフォルトでは最大のアップロードのサイズが1MBとなっていたため画像サイズによっては413エラーが発生していた。そのためNginxとPHPのアップロード時の最大サイズを10MBに修正。

### 該当Issue
#21 